### PR TITLE
fix(VIP-858): pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,19 @@ jobs:
     container:
       image: node:22
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Tests
         run: make test
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'
@@ -40,19 +40,19 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') && contains(github.ref_name, 'preview') }}
     needs: [ test ]
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Build
         run: make build
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'
@@ -67,20 +67,20 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') && startsWith(github.ref_name, 'v') }}
     needs: [ test ]
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Build
         run: make build
       - name: Setup Node for NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.1.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -88,7 +88,7 @@ jobs:
         run: npm install -g npm@11.5.1
       - name: Publish to NPM
         run: npm publish --provenance --access public
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'


### PR DESCRIPTION
## Summary
Pins all 3rd-party GitHub Actions to specific commit hashes to prevent supply chain attacks via mutable tags. Addresses Aikido medium severity alert.

| Action | Before | After |
|--------|--------|-------|
| [act10ns/slack](https://github.com/act10ns/slack/releases/tag/v2.1.0) | `@v1` | `@44541246747a30eb3102d87f7a4cc5471b0ffb7d` (v2.1.0) |
| [actions/checkout](https://github.com/actions/checkout/releases/tag/v4.2.2) | `@v3` | `@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) |
| [actions/setup-node](https://github.com/actions/setup-node/releases/tag/v4.1.0) | `@v4` | `@60edb5dd545a775178f52524783378180af0d1f8` (v4.1.0) |

## Test plan
- [x] Workflow YAML syntax is valid
- [ ] CI passes on merge

## Aikido
Resolves medium severity alert (issue group 14645202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)