### PR TITLE
fix(VIP-858): upgrade vulnerable JS deps and pin GHA actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,19 @@ jobs:
     container:
       image: node:22
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Tests
         run: make test
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'
@@ -40,19 +40,19 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') && contains(github.ref_name, 'preview') }}
     needs: [ test ]
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Build
         run: make build
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'
@@ -67,20 +67,20 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') && startsWith(github.ref_name, 'v') }}
     needs: [ test ]
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Build
         run: make build
       - name: Setup Node for NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -88,7 +88,7 @@ jobs:
         run: npm install -g npm@11.5.1
       - name: Publish to NPM
         run: npm publish --provenance --access public
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockchyp/blockchyp-ts",
-  "version": "2.28.0",
+  "version": "2.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockchyp/blockchyp-ts",
-      "version": "2.28.0",
+      "version": "2.30.1",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.6.0",
@@ -452,7 +452,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
       "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -524,7 +523,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -970,7 +968,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1047,7 +1044,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1489,7 +1485,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -2188,7 +2183,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2504,15 +2498,16 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -4537,7 +4532,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4718,7 +4712,6 @@
       "version": "5.4.5",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4893,7 +4886,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -4940,7 +4932,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4"
   },
+  "overrides": {
+    "sha.js": "^2.4.12",
+    "pbkdf2": "^3.1.5",
+    "follow-redirects": ">=1.16.0"
+  },
   "dependencies": {
     "aes-js": "^3.1.1",
     "axios": "^1.9.0",


### PR DESCRIPTION
## Summary

This PR addresses security vulnerabilities flagged by the Aikido security scanner.

### Dependency Upgrades (via npm `overrides`)

| CVE / Advisory | Package | Previous Resolved | Fixed Version | Severity |
|---|---|---|---|---|
| CVE-2025-9288 | `sha.js` | 2.4.12 | ^2.4.12 (pinned via override) | Critical |
| CVE-2025-6545 / CVE-2025-6547 | `pbkdf2` | 3.1.5 | ^3.1.5 (pinned via override) | High |
| GHSA-r4q5-vmmm-2653 | `follow-redirects` | 1.15.6 | >=1.16.0 (resolved: 1.16.0) | High |

The `overrides` field in `package.json` forces all transitive dependents to resolve these packages to safe minimum versions.

### GitHub Actions SHA Pinning (SAST finding)

All 3rd-party and GitHub-owned actions are now pinned to immutable commit SHAs to prevent supply-chain attacks:

| Action | Tag | Commit SHA |
|---|---|---|
| `actions/checkout` | v3 | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/setup-node` | v4 | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `act10ns/slack` | v1 | `87c73aef9f8838eb6feae81589a6b1487a4a9e08` |

Original tag names are preserved as inline comments for readability.

## Test plan

- [ ] CI passes (test, test-build, publish jobs all use pinned actions)
- [ ] `npm audit` shows follow-redirects resolved to 1.16.0 (no longer flagged for GHSA-r4q5-vmmm-2653)
- [ ] `package-lock.json` shows `follow-redirects` at `1.16.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)